### PR TITLE
added support for jquery functions with multiple config hashes

### DIFF
--- a/src/main/java/de/agilecoders/wicket/jquery/JQuery.java
+++ b/src/main/java/de/agilecoders/wicket/jquery/JQuery.java
@@ -321,8 +321,8 @@ public class JQuery implements IClusterable {
      * @param config       the function configuration
      * @return this instance for chaining
      */
-    public JQuery chain(final CharSequence functionName, final AbstractConfig config) {
-        functions.add(new ConfigurableFunction(functionName, config));
+    public JQuery chain(final CharSequence functionName, final AbstractConfig config, AbstractConfig ... extraConfigs) {
+        functions.add(new ConfigurableFunction(functionName, config, extraConfigs));
         return this;
     }
 
@@ -404,10 +404,30 @@ public class JQuery implements IClusterable {
          * @param config       the function configuration
          */
         protected ConfigurableFunction(final CharSequence functionName, final AbstractConfig config) {
+            this(functionName, config, null);
+        }
+
+        /**
+         * Construct.
+         *
+         * @param functionName The function name of this {@link IFunction} implementation
+         * @param config       the function configuration
+         */
+        protected ConfigurableFunction(final CharSequence functionName, final AbstractConfig config, AbstractConfig ... extraConfigs) {
             super(functionName);
 
-            if (!config.isEmpty()) {
-                addParameter(config.toJsonString());
+            // if multiple configs are provided, render all parameters, even if empty
+            if (extraConfigs != null) {
+                  addParameter(config.toJsonString());
+            } else if(!config.isEmpty()) {
+              // don't render any parameter if only one is provided and it is empty
+              addParameter(config.toJsonString());
+            }
+
+            if (extraConfigs != null) {
+                for (AbstractConfig extraConfig : extraConfigs) {
+                    addParameter(extraConfig.toJsonString());
+                }
             }
         }
     }

--- a/src/test/java/de/agilecoders/wicket/jquery/AbstractConfigTest.java
+++ b/src/test/java/de/agilecoders/wicket/jquery/AbstractConfigTest.java
@@ -2,9 +2,12 @@ package de.agilecoders.wicket.jquery;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import de.agilecoders.wicket.jquery.util.Json;
+
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static de.agilecoders.wicket.jquery.JQuery.$;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 
@@ -36,6 +39,22 @@ public class AbstractConfigTest extends Assert {
         assertEquals("{\"raw\":Hogan}", new RawValueConfig().toJsonString());
     }
 
+    @Test
+    public void multipleConfigurations() {
+        SimpleConfig configOne = new SimpleConfig();
+        SimpleConfig configTwo = new SimpleConfig();
+        String script = $(".foo").chain("foo", configOne, configTwo).get();
+        assertEquals("$('.foo').foo({\"integer\":1,\"string\":\"1\"},{\"integer\":1,\"string\":\"1\"});", script);
+    }
+
+    @Test
+    public void emptyConfig() {
+        EmptyConfig configOne = new EmptyConfig();
+        SimpleConfig configTwo = new SimpleConfig();
+        String script = $(".foo").chain("foo", configOne, configTwo).get();
+        assertEquals("$('.foo').foo({},{\"integer\":1,\"string\":\"1\"});", script);
+    }
+
     private static class RawValueConfig extends AbstractConfig {
         private static final IKey<Json.RawValue> raw = newKey("raw", null);
 
@@ -52,6 +71,11 @@ public class AbstractConfigTest extends Assert {
             put(string, "1");
             put(integer, 1);
         }
+    }
+
+    private static class EmptyConfig extends AbstractConfig {
+        private static final IKey<String> string = newKey("string", null);
+        private static final IKey<Integer> integer = newKey("integer", null);
     }
 
     private static class NestedConfig extends AbstractConfig {


### PR DESCRIPTION
For an example see http://twitter.github.io/typeahead.js/examples/#the-basics .

``` javascript
$('#the-basics .typeahead').typeahead({
    hint: true,
    highlight: true,
    minLength: 1
  },
  {
    name: 'states',
    displayKey: 'value',
    source: substringMatcher(states)
});
```
