### PR TITLE
String2.escapeMarkupId() has to escape with two backslashes instead of one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ target
 .project
 .classpath
 .settings%                                                      
+.settings/org.eclipse.core.resources.prefs
+.settings/org.eclipse.jdt.core.prefs
+.settings/org.eclipse.m2e.core.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,3 @@ target
 .project
 .classpath
 .settings%                                                      
-.settings/org.eclipse.core.resources.prefs
-.settings/org.eclipse.jdt.core.prefs
-.settings/org.eclipse.m2e.core.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <maven-bundle-plugin.version>2.5.2</maven-bundle-plugin.version>
-        <wicket.version>6.23.0</wicket.version>
+        <wicket.version>6.25.0</wicket.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <maven-bundle-plugin.version>2.5.2</maven-bundle-plugin.version>
-        <wicket.version>6.25.0</wicket.version>
+        <wicket.version>6.23.0</wicket.version>
     </properties>
 
     <scm>

--- a/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
+++ b/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
@@ -52,7 +52,7 @@ public final class Strings2 {
         // create pattern for: !"#$%&'()*+,./:;<=>?@[\]^`{|}~
         final StringCharacterIterator iterator = new StringCharacterIterator(markupId.toString());
         final StringBuilder result = new StringBuilder((int) (markupId.length() * 1.5));
-        final String escape = "\\";
+        final String escape = "\\\\";
 
         char c = iterator.current();
         while (c != CharacterIterator.DONE) {

--- a/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
+++ b/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
@@ -1,10 +1,10 @@
 package de.agilecoders.wicket.jquery.util;
 
-import java.text.CharacterIterator;
-import java.text.StringCharacterIterator;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.util.lang.Args;
+
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
 
 /**
  * helper class to handle string interaction
@@ -12,73 +12,73 @@ import org.apache.wicket.util.lang.Args;
  * @author miha
  */
 public final class Strings2 {
-	private static char[] ESCAPE_CHARS = new char[] { '!', '"', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '>', '=', '?', '@', '[',
-			']', '\\', '^', '`', '{', '}', '|', '~', '\'' };
+    private static char[] ESCAPE_CHARS = new char[] {
+            '!', '"', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.',
+            '/', ':', ';', '<', '>', '=', '?', '@', '[', ']', '\\', '^', '`',
+            '{', '}', '|', '~', '\''
+    };
 
-	/**
-	 * ensures a non null value.
-	 *
-	 * @param value
-	 *            string value to transform to an empty string if it's null
-	 * @return non null value
-	 */
-	public static String nullToEmpty(final String value) {
-		return value != null ? value : "";
-	}
+    /**
+     * ensures a non null value.
+     *
+     * @param value string value to transform to an empty string if it's null
+     * @return non null value
+     */
+    public static String nullToEmpty(final String value) {
+        return value != null ? value : "";
+    }
 
-	/**
-	 * Returns a markup id that is JQuery-safe and could be used as a selector.
-	 *
-	 * @param component
-	 *            the component which markup id should be return
-	 * @return the component's markup id that is escaped so that it could be used as JQuery selector
-	 */
-	public static CharSequence getMarkupId(final Component component) {
-		Args.notNull(component, "component");
-		String markupId = component.getMarkupId(true);
-		return escapeMarkupId(markupId);
-	}
+    /**
+     * Returns a markup id that is JQuery-safe and could be used as a selector.
+     *
+     * @param component the component which markup id should be return
+     * @return the component's markup id that is escaped so that it could be used as JQuery selector
+     */
+    public static CharSequence getMarkupId(final Component component) {
+        Args.notNull(component, "component");
+        String markupId = component.getMarkupId(true);
+        return escapeMarkupId(markupId);
+    }
 
-	/**
-	 * Returns a markup id that is JQuery-safe and could be used as a selector.
-	 *
-	 * @param markupId
-	 *            the markup id to escape
-	 * @return the component's markup id that is escaped so that it could be used as JQuery selector
-	 */
-	public static CharSequence escapeMarkupId(final CharSequence markupId) {
-		Args.notNull(markupId, "markupId");
+    /**
+     * Returns a markup id that is JQuery-safe and could be used as a selector.
+     *
+     * @param markupId the markup id to escape
+     * @return the component's markup id that is escaped so that it could be used as JQuery selector
+     */
+    public static CharSequence escapeMarkupId(final CharSequence markupId) {
+        Args.notNull(markupId, "markupId");
 
-		// create pattern for: !"#$%&'()*+,./:;<=>?@[\]^`{|}~
-		final StringCharacterIterator iterator = new StringCharacterIterator(markupId.toString());
-		final StringBuilder result = new StringBuilder((int) (markupId.length() * 1.5));
-		final String escape = "\\\\";
+        // create pattern for: !"#$%&'()*+,./:;<=>?@[\]^`{|}~
+        final StringCharacterIterator iterator = new StringCharacterIterator(markupId.toString());
+        final StringBuilder result = new StringBuilder((int) (markupId.length() * 1.5));
+        final String escape = "\\";
 
-		char c = iterator.current();
-		while (c != CharacterIterator.DONE) {
-			boolean escaped = false;
-			for (char x : ESCAPE_CHARS) {
-				if (x == c) {
-					result.append(escape).append(c);
-					escaped = true;
-					break;
-				}
-			}
+        char c = iterator.current();
+        while (c != CharacterIterator.DONE) {
+            boolean escaped = false;
+            for (char x : ESCAPE_CHARS) {
+                if (x == c) {
+                    result.append(escape).append(c);
+                    escaped = true;
+                    break;
+                }
+            }
 
-			if (!escaped) {
-				result.append(c);
-			}
+            if (!escaped) {
+                result.append(c);
+            }
 
-			c = iterator.next();
-		}
+            c = iterator.next();
+        }
 
-		return result.toString();
-	}
+        return result.toString();
+    }
 
-	/**
-	 * private constructor to prevent instantiation of util class.
-	 */
-	private Strings2() {
-		throw new UnsupportedOperationException();
-	}
+    /**
+     * private constructor to prevent instantiation of util class.
+     */
+    private Strings2() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
+++ b/src/main/java/de/agilecoders/wicket/jquery/util/Strings2.java
@@ -1,10 +1,10 @@
 package de.agilecoders.wicket.jquery.util;
 
-import org.apache.wicket.Component;
-import org.apache.wicket.util.lang.Args;
-
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.util.lang.Args;
 
 /**
  * helper class to handle string interaction
@@ -12,73 +12,73 @@ import java.text.StringCharacterIterator;
  * @author miha
  */
 public final class Strings2 {
-    private static char[] ESCAPE_CHARS = new char[] {
-            '!', '"', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.',
-            '/', ':', ';', '<', '>', '=', '?', '@', '[', ']', '\\', '^', '`',
-            '{', '}', '|', '~', '\''
-    };
+	private static char[] ESCAPE_CHARS = new char[] { '!', '"', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.', '/', ':', ';', '<', '>', '=', '?', '@', '[',
+			']', '\\', '^', '`', '{', '}', '|', '~', '\'' };
 
-    /**
-     * ensures a non null value.
-     *
-     * @param value string value to transform to an empty string if it's null
-     * @return non null value
-     */
-    public static String nullToEmpty(final String value) {
-        return value != null ? value : "";
-    }
+	/**
+	 * ensures a non null value.
+	 *
+	 * @param value
+	 *            string value to transform to an empty string if it's null
+	 * @return non null value
+	 */
+	public static String nullToEmpty(final String value) {
+		return value != null ? value : "";
+	}
 
-    /**
-     * Returns a markup id that is JQuery-safe and could be used as a selector.
-     *
-     * @param component the component which markup id should be return
-     * @return the component's markup id that is escaped so that it could be used as JQuery selector
-     */
-    public static CharSequence getMarkupId(final Component component) {
-        Args.notNull(component, "component");
-        String markupId = component.getMarkupId(true);
-        return escapeMarkupId(markupId);
-    }
+	/**
+	 * Returns a markup id that is JQuery-safe and could be used as a selector.
+	 *
+	 * @param component
+	 *            the component which markup id should be return
+	 * @return the component's markup id that is escaped so that it could be used as JQuery selector
+	 */
+	public static CharSequence getMarkupId(final Component component) {
+		Args.notNull(component, "component");
+		String markupId = component.getMarkupId(true);
+		return escapeMarkupId(markupId);
+	}
 
-    /**
-     * Returns a markup id that is JQuery-safe and could be used as a selector.
-     *
-     * @param markupId the markup id to escape
-     * @return the component's markup id that is escaped so that it could be used as JQuery selector
-     */
-    public static CharSequence escapeMarkupId(final CharSequence markupId) {
-        Args.notNull(markupId, "markupId");
+	/**
+	 * Returns a markup id that is JQuery-safe and could be used as a selector.
+	 *
+	 * @param markupId
+	 *            the markup id to escape
+	 * @return the component's markup id that is escaped so that it could be used as JQuery selector
+	 */
+	public static CharSequence escapeMarkupId(final CharSequence markupId) {
+		Args.notNull(markupId, "markupId");
 
-        // create pattern for: !"#$%&'()*+,./:;<=>?@[\]^`{|}~
-        final StringCharacterIterator iterator = new StringCharacterIterator(markupId.toString());
-        final StringBuilder result = new StringBuilder((int) (markupId.length() * 1.5));
-        final String escape = "\\";
+		// create pattern for: !"#$%&'()*+,./:;<=>?@[\]^`{|}~
+		final StringCharacterIterator iterator = new StringCharacterIterator(markupId.toString());
+		final StringBuilder result = new StringBuilder((int) (markupId.length() * 1.5));
+		final String escape = "\\\\";
 
-        char c = iterator.current();
-        while (c != CharacterIterator.DONE) {
-            boolean escaped = false;
-            for (char x : ESCAPE_CHARS) {
-                if (x == c) {
-                    result.append(escape).append(c);
-                    escaped = true;
-                    break;
-                }
-            }
+		char c = iterator.current();
+		while (c != CharacterIterator.DONE) {
+			boolean escaped = false;
+			for (char x : ESCAPE_CHARS) {
+				if (x == c) {
+					result.append(escape).append(c);
+					escaped = true;
+					break;
+				}
+			}
 
-            if (!escaped) {
-                result.append(c);
-            }
+			if (!escaped) {
+				result.append(c);
+			}
 
-            c = iterator.next();
-        }
+			c = iterator.next();
+		}
 
-        return result.toString();
-    }
+		return result.toString();
+	}
 
-    /**
-     * private constructor to prevent instantiation of util class.
-     */
-    private Strings2() {
-        throw new UnsupportedOperationException();
-    }
+	/**
+	 * private constructor to prevent instantiation of util class.
+	 */
+	private Strings2() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
+++ b/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
@@ -1,9 +1,9 @@
 package de.agilecoders.wicket.jquery.util;
 
+import org.junit.Test;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-
-import org.junit.Test;
 
 /**
  * tests the {@link de.agilecoders.wicket.jquery.util.Strings2} class
@@ -12,13 +12,13 @@ import org.junit.Test;
  */
 public class Strings2Test {
 
-	@Test
-	public void escapeCharacters() {
-		assertThat(
-				Strings2.escapeMarkupId("!\"#$%&'()*+,./:;<=>?@[\\]^`{|}~").toString(),
-				is("\\\\!\\\\\"\\\\#\\\\$\\\\%\\\\&\\\\'\\\\(\\\\)\\\\*\\\\+\\\\,\\\\.\\\\/\\\\:\\\\;\\\\<\\\\=\\\\>\\\\?\\\\@\\\\[\\\\\\\\\\]\\\\^\\\\`\\\\{\\\\|\\\\}\\\\~"));
+    @Test
+    public void escapeCharacters() {
+        assertThat(Strings2.escapeMarkupId("!\"#$%&'()*+,./:;<=>?@[\\]^`{|}~").toString(),
+                   is("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~"));
 
-		assertThat(Strings2.escapeMarkupId("my.custom.markup-id").toString(), is("my\\\\.custom\\\\.markup-id"));
-	}
+        assertThat(Strings2.escapeMarkupId("my.custom.markup-id").toString(),
+                   is("my\\.custom\\.markup-id"));
+    }
 
 }

--- a/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
+++ b/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
@@ -15,10 +15,10 @@ public class Strings2Test {
     @Test
     public void escapeCharacters() {
         assertThat(Strings2.escapeMarkupId("!\"#$%&'()*+,./:;<=>?@[\\]^`{|}~").toString(),
-                   is("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~"));
+                   is("\\\\!\\\\\"\\\\#\\\\$\\\\%\\\\&\\\\'\\\\(\\\\)\\\\*\\\\+\\\\,\\\\.\\\\/\\\\:\\\\;\\\\<\\\\=\\\\>\\\\?\\\\@\\\\[\\\\\\\\\\]\\\\^\\\\`\\\\{\\\\|\\\\}\\\\~"));
 
         assertThat(Strings2.escapeMarkupId("my.custom.markup-id").toString(),
-                   is("my\\.custom\\.markup-id"));
+                   is("my\\\\.custom\\\\.markup-id"));
     }
 
 }

--- a/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
+++ b/src/test/java/de/agilecoders/wicket/jquery/util/Strings2Test.java
@@ -1,9 +1,9 @@
 package de.agilecoders.wicket.jquery.util;
 
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
 
 /**
  * tests the {@link de.agilecoders.wicket.jquery.util.Strings2} class
@@ -12,13 +12,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class Strings2Test {
 
-    @Test
-    public void escapeCharacters() {
-        assertThat(Strings2.escapeMarkupId("!\"#$%&'()*+,./:;<=>?@[\\]^`{|}~").toString(),
-                   is("\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~"));
+	@Test
+	public void escapeCharacters() {
+		assertThat(
+				Strings2.escapeMarkupId("!\"#$%&'()*+,./:;<=>?@[\\]^`{|}~").toString(),
+				is("\\\\!\\\\\"\\\\#\\\\$\\\\%\\\\&\\\\'\\\\(\\\\)\\\\*\\\\+\\\\,\\\\.\\\\/\\\\:\\\\;\\\\<\\\\=\\\\>\\\\?\\\\@\\\\[\\\\\\\\\\]\\\\^\\\\`\\\\{\\\\|\\\\}\\\\~"));
 
-        assertThat(Strings2.escapeMarkupId("my.custom.markup-id").toString(),
-                   is("my\\.custom\\.markup-id"));
-    }
+		assertThat(Strings2.escapeMarkupId("my.custom.markup-id").toString(), is("my\\\\.custom\\\\.markup-id"));
+	}
 
 }


### PR DESCRIPTION
selectors.html - "If you wish to use any of the meta-characters ( such as !"#$%&'()*+,./:;<=>?@[\]^`{|}~ ) as a literal part of a name, you must escape the character with two backslashes: \\."