### PR TITLE
UnsupportedOperationException because Collections.emptyList() is immutable

### DIFF
--- a/src/main/java/de/agilecoders/wicket/jquery/function/JavaScriptInlineFunction.java
+++ b/src/main/java/de/agilecoders/wicket/jquery/function/JavaScriptInlineFunction.java
@@ -2,7 +2,8 @@ package de.agilecoders.wicket.jquery.function;
 
 import org.apache.wicket.util.lang.Objects;
 
-import java.util.Collections;
+import de.agilecoders.wicket.jquery.util.Generics2;
+
 import java.util.List;
 
 import static de.agilecoders.wicket.jquery.util.Strings2.nullToEmpty;
@@ -19,7 +20,7 @@ public class JavaScriptInlineFunction extends AbstractFunction {
      * @param functionBody the function body as string
      */
     public JavaScriptInlineFunction(final String functionBody) {
-        this(functionBody, Collections.<CharSequence>emptyList());
+        this(functionBody, Generics2.<CharSequence>newArrayList());
     }
 
     /**

--- a/src/test/java/de/agilecoders/wicket/jquery/function/JavaScriptInlineFunctionTest.java
+++ b/src/test/java/de/agilecoders/wicket/jquery/function/JavaScriptInlineFunctionTest.java
@@ -1,0 +1,17 @@
+package de.agilecoders.wicket.jquery.function;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JavaScriptInlineFunctionTest extends Assert {
+
+	@Test
+	public void javascriptInlineFunctionWithAddParameter() {
+		JavaScriptInlineFunction function = new JavaScriptInlineFunction("alert(event);");
+		function.addParameter("event");
+		assertThat(function.build(), is(equalTo("function(event){alert(event);}")));
+	}
+}


### PR DESCRIPTION
java.lang.UnsupportedOperationException
	at java.util.AbstractList.add(AbstractList.java:131)
	at java.util.AbstractList.add(AbstractList.java:91)
	at de.agilecoders.wicket.jquery.function.AbstractFunction.addParameter(AbstractFunction.java:62)
	at de.agilecoders.wicket.jquery.function.JavaScriptInlineFunctionTest.javascriptInlineFunctionWithAddParameter(JavaScriptInlineFunctionTest.java:14)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
	at java.lang.reflect.Method.invoke(Method.java:597)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)

